### PR TITLE
ATO-418

### DIFF
--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -95,13 +95,14 @@ public:
   static const std::vector<int> &    GetFillColors(const char *style){return AliDrawStyle::fFillColors[style];};
   // CSS like attribute fields parsing
   static Bool_t  IsSelected(TString selectors, TString elementID, TString classID, TString objectID);
-  static TString GetProperty(const char * styleName, TString propertyName, TString elementID, TString classID, TString objectID);
+  static TString GetProperty(const char * styleName, TString propertyName, TString elementID, TString classID, TString objectID, Int_t verbose = 4);
   static TString  GetPropertyValue(TString input, TString propertyName);
   //static Int_t    GetObjectIndex(TString &objName);
   static void     GetIds(TObject *cObj, TString &elementID, TString &classSet, TString &objectID);
-  static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index, Bool_t &status);
+  static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index, Bool_t &status, Int_t verbose=4);
   static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index, Bool_t &status);
   static Double_t UnitsConverter(TString value, Double_t k);
+  static Int_t    ConvertColor(TString inputValues, Int_t index, Bool_t &status, Int_t verbose = 4);
   static TObjArray * ReadCSSFile(const char *  inputName, TObjArray * array=NULL, Int_t verbose=0);
   static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, std::fstream *cssOut=NULL);
   //

--- a/STAT/AliPainter.h
+++ b/STAT/AliPainter.h
@@ -14,6 +14,7 @@
 
 class TPad;
 class TMultiGraph;
+class TFormula;
 #include "TObject.h"
 #include <vector>
 #include <map>
@@ -22,21 +23,23 @@ class TMultiGraph;
 #include "TPad.h"
 
 class AliPainter : public TObject{
-
-public:
-    static void       DivideTPad(TPad *pad, const char *division, const char *classID);
-    static void       SetMultiGraphTimeAxis(TMultiGraph *graph, TString option);
-    static void       DrawHistogram(char *expresion, const TObjArray *histogramArray, TPad *pad=NULL, TObjArray *metaData=NULL, TObjArray *keepArray=NULL, Int_t verbose=4);
-//static TObject   *GetHistogram(TObject *hisN, TString range, std::vector<TString> fitOptions);
-    static TPad      *SetPadMargin(TPad *cPad, const char *position, const char *wMargin, const char *units, Double_t mValue, Int_t iCol, Int_t nCols);
-public:
-    typedef std::map<int, std::vector<int> > axisRangesMap;
+  public:
+    static TPad *DivideTPad(const char *division, const char *classID="",TPad *pad=nullptr, Int_t verbose=4);
+    static void SetMultiGraphTimeAxis(TMultiGraph *graph, TString option);
+    static void DrawHistogram(char *expresion, const TObjArray *histogramArray, TPad *pad=nullptr, TObjArray *metaData=nullptr, TObjArray *keepArray=nullptr, Int_t verbose=4);
+    static TPad *SetPadMargin(TPad *cPad, const char *position, const char *wMargin, const char *units, Double_t mValue, Int_t iCol, Int_t nCols);
+    //static Double_t GetLimitValue(TString expression, TPad *cPad);
+    //static void ApplyLimitValue();
+    ClassDef(AliPainter,1);
+  //TODO: it should be protected for inheritor test class @Boris
+  //protected:
+    typedef std::map<Int_t, std::vector<TString> > axisRangesMap;
     static std::map<TString, TString> optionValues;
-ClassDef(AliPainter,1);
+    static std::map<TString, Double_t> statValues;
     static void ArgsParser(TString exprsn, TString &hisName, TString &projections, std::vector<TString> &fitOptions, std::vector<TString> &rangesStrings, Int_t verbose = 4);
-    static std::vector<TString> OptParser(const TString fitStr, const char d[2], Int_t defSize);
-    static void OptionsParser(const TString optionsStr);
-    static void  RegisterDefaultOptions();
+    static std::vector<TString> OptionStringParser(const TString optStr, const char d[2], Int_t defSize);
+    static void PandasOptionParser(const TString optionsStr);
+    static void RegisterDefaultOptions();
     static std::vector<TString> RangesParser(TString inputRangesStr);
     static void RangesToMap (TString range , Int_t axisNum, axisRangesMap &result);
     static void RangesMapToString(Int_t n, axisRangesMap result, std::vector<TString> arr, std::vector<TString> &res);

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -30,6 +30,7 @@ root.exe -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTes
 
 void AliDrawStyleTest_StyleArray();
 void AliDrawStyleTest_Attributes();
+void AliDrawStyleTest_ConvertColor();
 void AliDrawStyleTest_GetIntValues();
 void AliDrawStyleTest_GetFloatValues();
 //  void AliDrawStyleTest_CSSReadWrite();
@@ -40,6 +41,7 @@ TCanvas *MakeTestPlot(Int_t nHis);
 void AliDrawStyleTest(){
   AliDrawStyleTest_StyleArray();
   AliDrawStyleTest_Attributes();
+  AliDrawStyleTest_ConvertColor();
   AliDrawStyleTest_GetIntValues();
   AliDrawStyleTest_GetFloatValues();
   //  AliDrawStyleTest_CSSReadWrite();
@@ -76,108 +78,143 @@ void AliDrawStyleTest_StyleArray(){
 }
 
 void AliDrawStyleTest_Attributes(){
-  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  TString input="{marker_style:25,21,22,23; marker_color:1,2,4,5;}";
   if ( AliDrawStyle::GetPropertyValue(input,"marker_color").Contains("1,2,4,5")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_color\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(%s, \"marker_color\")- IsOK", input.Data());
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_color\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(%s, \"marker_color\")- FAILED", input.Data());
   }
   if ( AliDrawStyle::GetPropertyValue(input,"marker_style").Contains("25,21,22,23")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_style\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(%s, \"marker_style\")- IsOK", input.Data());
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_style\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(%s, \"marker_style\")- FAILED", input.Data());
+  }
+}
+
+void AliDrawStyleTest_ConvertColor() {
+  TString input="25,rgb(0,0,0),#0000FF,5,rgb(255,255,0),#00FFFF";
+  Bool_t status;
+  if ( AliDrawStyle::ConvertColor(input,0,status) == 25){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 0, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 0, \"%d\")- FAILED", input.Data(), status);
+  }
+  if ( AliDrawStyle::ConvertColor(input,1,status) == 1){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 1, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 1, \"%d\")- FAILED", input.Data(), status);
+  }
+  if ( AliDrawStyle::ConvertColor(input,2,status) == 4){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 2, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 2, \"%d\")- FAILED", input.Data(), status);
+  }
+  if ( AliDrawStyle::ConvertColor(input,3,status) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 3, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 3, \"%d\")- FAILED", input.Data(), status);
+  }
+  if ( AliDrawStyle::ConvertColor(input,4,status) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 4, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 4, \"%d\")- FAILED", input.Data(), status);
+  }
+  if ( AliDrawStyle::ConvertColor(input,5,status) == 7){
+    ::Info("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 5, \"%d\")- IsOK", input.Data(), status);
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::ConvertColor(\"%s\", 5, \"%d\")- FAILED", input.Data(), status);
   }
 }
 
 /// test GetIntValues
 void AliDrawStyleTest_GetIntValues(){
-  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  TString input="{marker_style:25,21,22,23; marker_color:1,2,4,5;}";
   Bool_t status;
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",0, status) == 1){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",0, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",0, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",1, status) == 2){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",1, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",1, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2, status) == 4){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",2, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",2, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",3, status) == 5){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",3, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_color\",3, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0, status) == 25){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",0, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",0, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",1, status) == 21){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",1, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",1, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",2, status) == 22){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",2, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",2, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3, status) == 23){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",3, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(%s, \"marker_style\",3, \"%d\")- FAILED", input.Data(), status);
   }
 }
 
 ///
 void AliDrawStyleTest_GetFloatValues(){
-  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  TString input="{marker_style:25,21,22,23; marker_color:1,2,4,5;}";
   Bool_t status;
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",0, status) == 1){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",0, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",0, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",1, status) == 2){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",1, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",1, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",2, status) == 4){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",2, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",2, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",3, status) == 5){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",3, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_color\",3, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",0, status) == 25){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",0, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",0, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",1, status) == 21){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",1, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",1, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",2, status) == 22){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",2, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",2, \"%d\")- FAILED", input.Data(), status);
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",3, status) == 23){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",3, \"%d\")- IsOK", input.Data(), status);
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(%s, \"marker_style\",3, \"%d\")- FAILED", input.Data(), status);
   }
 }
 
@@ -189,13 +226,13 @@ void AliDrawStyleTest_GetFloatValues(){
 //
 //   if (gSystem->GetFromPipe(TString("[ -f ") + TString("$AliRoot_SRC/STAT/test/alirootTestStyle.css") +  TString(" ] && echo 1 || echo 0")) == "0") {
 //     std::cout << "File doesn't exist1" << std::endl;
-//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- ");
 //     return;
 //   }
 //   TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0);
 //   if (cssArray == NULL) {
 //     std::cout << "null-pointer error" << std::endl;
-//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- ");
 //     return;
 //   }
 //   AliDrawStyle::WriteCSSFilecssArray,"$AliRoot_SRC/STAT/test/test.css");
@@ -205,7 +242,7 @@ void AliDrawStyleTest_GetFloatValues(){
 //
 //   for (Int_t i = 0; i < cssArray->GetEntriesFast(); i++){
 //     if ((TString(cssArray->At(i)->GetName()).ReplaceAll("\n", "") == TString(cssArrayFromTest->At(i)->GetName()).ReplaceAll("\n", "")) && TString(cssArray->At(i)->GetTitle()).ReplaceAll("\n", "") == TString(cssArrayFromTest->At(i)->GetTitle()).ReplaceAll("\n", "")) ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- ");
-//     else ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//     else ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- ");
 //
 //   }
 //   gSystem->GetFromPipe("rm -f $AliRoot_SRC/STAT/test/test.css");
@@ -214,30 +251,30 @@ void AliDrawStyleTest_GetFloatValues(){
 
 void  AliDrawStyleTest_GetProperty(){
   AliDrawStyle::RegisterCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "1,2,3,4"){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- IsOK");
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker-size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "1,2,3,4"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- FAILED");
   }
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TF1", "Status", "obj4") == "17,18,19,20"){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TF1\", \"Status\", \"obj4\")- IsOK");
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker-size", "TF1", "Status", "obj4") == "17,18,19,20"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-size\", \"TF1\", \"Status\", \"obj4\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TF1\", \"Status\", \"obj4\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-size\", \"TF1\", \"Status\", \"obj4\")- FAILED");
   }
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line_color", "TGraphErrors", "Warning", "asdasobj56") == "41,42,43,44"){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- IsOK");
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line-color", "TGraphErrors", "Warning", "asdasobj56") == "41,42,43,44"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line-color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line-color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- FAILED");
   }
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_color", "SomeNotExistingClass", "SomeNotExistingStatus", "obj3") == "37,38,39,40"){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- IsOK");
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker-color", "SomeNotExistingClass", "SomeNotExistingStatus", "obj3") == "37,38,39,40"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker-color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- FAILED");
   }
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line_color", "TH1", "Warning", "obj1") == "57,58,59,60"){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TH1\", \"Warning\", \"obj1\")- IsOK");
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line-color", "TH1", "Warning", "obj1") == "57,58,59,60"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line-color\", \"TH1\", \"Warning\", \"obj1\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TH1\", \"Warning\", \"obj1\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line-color\", \"TH1\", \"Warning\", \"obj1\")- FAILED");
   }
 
 }
@@ -258,8 +295,8 @@ void AliDrawStyleTest_ApplyCssStyle(){
   AliDrawStyle::ApplyCssStyle(canv, "test2");
   AliDrawStyle::ApplyCssStyle(canv, "test1");
   canv->Print("test2-1.xml");
-  Int_t nDiff = gSystem->GetFromPipe("diff  test1.xml test2-1.xml  | wc -l").Atoi()-4;
-  if (nDiff == 0) {
+  Int_t nDiff = gSystem->GetFromPipe("diff  test1.xml test2-1.xml  | wc -l").Atoi();
+  if (nDiff - 4  == 0 || nDiff - 6 == 0) {
     ::Info("AliDrawStyleTest","AliDrawStyle::ApplyStyle(\"canv\",\"test1\")- IsOK");
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::ApplyStyle(\"canv\",\"test1\")- FAILED");
@@ -269,7 +306,7 @@ void AliDrawStyleTest_ApplyCssStyle(){
 TCanvas *MakeTestPlot(Int_t nHis) {
   TRandom r;
   TCanvas *exampleCanvas = new TCanvas("c1", "The AliDrawStyle::ApplyCssStyle example", 200, 10, 1200, 900);
-  AliPainter::DivideTPad(exampleCanvas,"<vertical>[1l,1r]", "Pad");
+  AliPainter::DivideTPad("<vertical>[1l,1r]", "Raw", exampleCanvas);
   exampleCanvas->cd(1);
   TH1F *hisArray[nHis];
   for (Int_t i = 0; i < nHis; i++) {

--- a/STAT/test/AliPainterTest.C
+++ b/STAT/test/AliPainterTest.C
@@ -8,15 +8,280 @@ AliPainterTest();
 root.exe -b -q  $AliRoot_SRC/STAT/test/AliPainterTest.C+ | tee AliPainterTest.log
 \endcode
 */
-
+//TODO: if methods in AliPainter.h will be private we should create new class AliPainterTest inherits from Alipainter. @Boris
 #include "AliPainter.h"
+#include "TError.h"
+#include "TCanvas.h"
+#include "Riostream.h"
+#include "Rtypes.h"
+#include "AliDrawStyle.h"
+#include "TSystem.h"
+#include "TPad.h"
 
-void DivideTPadTest();
-void SetMultiGraphTimeAxisTest();
-void DrawHistogramTest();
+void AliPainterTest_OptionStringParser();
+void AliPainterTest_PandasOptionParser();
+void AliPainterTest_RangesParser();
+void AliPainterTest_ArgsParser();
+void AliPainterTest_DivideTPad();
+//void AliPainterTest_SetMultiGraphTimeAxisTest();
+//void AliPainterTest_DrawHistogramTest();
+//void AliPainterTest_GetLimitValueTest();
+//void AliPainterTest_ApplyLimitValueTest();
 
 void AliPainterTest(){
-  DivideTPadTest();
-  SetMultiGraphTimeAxisTest();
-  DrawHistogramTest();
+  AliPainterTest_OptionStringParser();
+  AliPainterTest_PandasOptionParser();
+  AliPainterTest_RangesParser();
+  AliPainterTest_ArgsParser();
+  AliPainterTest_DivideTPad();
+//  AliPainterTest_SetMultiGraphTimeAxisTest();
+//  AliPainterTest_DrawHistogramTest();
+//  AliPainterTest_GetLimitValueTest();
+//  AliPainterTest_ApplyLimitValueTest();
+}
+
+void AliPainterTest_OptionStringParser(){
+  Int_t result = 0;
+  TString input="gaus,W,fitFunction(1,2,3),E,10,200";
+  std::vector<TString> optValuesHandle;
+  std::vector<TString> optValues;
+  optValuesHandle.push_back(TString("gaus"));
+  optValuesHandle.push_back(TString("W"));
+  optValuesHandle.push_back(TString("fitFunction(1,2,3)"));
+  optValuesHandle.push_back(TString("E"));
+  optValuesHandle.push_back(TString("10"));
+  optValuesHandle.push_back(TString("200"));
+  optValues = AliPainter::OptionStringParser(input,"()",6);
+  for (Int_t i = 0; i < 6; i++) if (optValuesHandle[i] != optValues[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- IsOK", input.Data());
+  }
+  input="gaus,,fitFunction(),,10.234";
+  optValuesHandle.clear();
+  optValues.clear();
+  optValuesHandle.push_back(TString("gaus"));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString("fitFunction()"));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString("10.234"));
+  optValuesHandle.push_back(TString(""));
+  optValues = AliPainter::OptionStringParser(input,"()",6);
+  for (Int_t i = 0; i < 6; i++) if (optValuesHandle[i] != optValues[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- IsOK", input.Data());
+  }
+  input="div=0,class=Mass,dOption=E,xlim=[0,10000]";
+  optValuesHandle.clear();
+  optValues.clear();
+  optValuesHandle.push_back(TString("div=0"));
+  optValuesHandle.push_back(TString("class=Mass"));
+  optValuesHandle.push_back(TString("dOption=E"));
+  optValuesHandle.push_back(TString("xlim=[0,10000]"));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValues = AliPainter::OptionStringParser(input,"[]",6);
+  for (Int_t i = 0; i < 6; i++) if (optValuesHandle[i] != optValues[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"[]\",6)- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"[]\",6)- IsOK", input.Data());
+  }
+  input="";
+  optValuesHandle.clear();
+  optValues.clear();
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValuesHandle.push_back(TString(""));
+  optValues = AliPainter::OptionStringParser(input,"[]",6);
+  for (Int_t i = 0; i < 6; i++) if (optValuesHandle[i] != optValues[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"[]\",6)- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"[]\",6)- IsOK", input.Data());
+  }
+  optValues.clear();
+  optValues = AliPainter::OptionStringParser(input,"()",6);
+  for (Int_t i = 0; i < 6; i++) if (optValuesHandle[i] != optValues[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::OptionStringParser(\"%s\",\"()\",6)- IsOK", input.Data());
+  }
+}
+
+void AliPainterTest_PandasOptionParser(){
+  AliPainter::RegisterDefaultOptions();
+  TString input="div=0";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["div"] != TString("0")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+  input="class=Mass";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["class"] != TString("Mass")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+  input="dOption=E";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["dOption"] != TString("E")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+  input="xlim=[10.123,20.435]";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["xlim"] != TString("[10.123,20.435]")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+  input="zlim=[]";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["zlim"] != TString("[]")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+
+  input="ylim=";
+  AliPainter::PandasOptionParser(input);
+  if (AliPainter::optionValues["ylim"] != TString("")) {
+    ::Error("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::PandasOptionParser(\"%s\")- IsOK", input.Data());
+  }
+}
+
+void AliPainterTest_RangesParser() {
+  TString input = "10,20";
+  std::vector<TString> outPut = AliPainter::RangesParser(input);
+  if (outPut[0] != input) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::RangesParser(\"%s\")- IsOK", input.Data());
+  }
+  input = "10.23,20,54,32.45,43,65.34";
+  outPut.clear();
+  outPut = AliPainter::RangesParser(input);
+  if (outPut[0] != input) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::RangesParser(\"%s\")- IsOK", input.Data());
+  }
+  input = "0:20:10:10";
+  outPut.clear();
+  outPut = AliPainter::RangesParser(input);
+  std::vector<TString> outPutHandle;
+  outPutHandle.push_back("0,10");
+  outPutHandle.push_back("10,20");
+  Int_t result = 0;
+  if (outPutHandle.size() != outPut.size()) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  for (Int_t i = 0; i < (Int_t) outPutHandle.size(); i++) if (outPutHandle[i] != outPut[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::RangesParser(\"%s\")- IsOK", input.Data());
+  }
+  input = "10:20:10,0:40:10:20,30,40";
+  outPut.clear();
+  outPut = AliPainter::RangesParser(input);
+  outPutHandle.clear();
+  outPutHandle.push_back("10,10,0,20,30,40");
+  outPutHandle.push_back("10,10,10,30,30,40");
+  outPutHandle.push_back("10,10,20,40,30,40");
+  outPutHandle.push_back("20,20,0,20,30,40");
+  outPutHandle.push_back("20,20,10,30,30,40");
+  outPutHandle.push_back("20,20,20,40,30,40");
+  result = 0;
+  if (outPutHandle.size() != outPut.size()) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  for (Int_t i = 0; i < (Int_t) outPut.size(); i++) if (outPutHandle[i] != outPut[i]) result++;
+  if (result > 0) {
+    ::Error("AliPainterTest","AliPainter::RangesParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::RangesParser(\"%s\")- IsOK", input.Data());
+  }
+}
+
+void AliPainterTest_ArgsParser(){
+  Int_t result=0;
+  TString input="hisK0DMassQPtTgl(20,80,0:80:20:20,0,10)(0)(gaus,W)(class=Mass,dOption=E)";
+  TString hisName = "";
+  TString projections = "";
+  std::vector<TString> fitOptions;
+  std::vector<TString> rangesStrings;
+
+  AliPainter::ArgsParser(input, hisName, projections, fitOptions, rangesStrings,4);
+  if (hisName != TString("hisK0DMassQPtTgl")){
+    ::Error("AliPainterTest","AliPainter::ArgsParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::ArgsParser(\"%s\")- IsOK", input.Data());
+  }
+  if (projections != TString("0")){
+    ::Error("AliPainterTest","AliPainter::ArgsParser(\"%s\")- FAILED", input.Data());
+    return;
+  }
+  else{
+    ::Info("AliPainterTest","AliPainter::ArgsParser(\"%s\")- IsOK", input.Data());
+  }
+}
+
+void AliPainterTest_DivideTPad() {
+  TCanvas *canvasQATest = new TCanvas("canvasQATest", "canvasQATest", 1200, 800);
+  AliPainter::DivideTPad("<horizontal>[1b,1m,1m,1lst0.3]", "", canvasQATest);
+  Int_t result = 0;
+  TPad *cPad = (TPad *) canvasQATest->cd(1);
+  if (cPad->GetAbsXlowNDC() + cPad->GetBottomMargin() != 0.0) result++;
+  cPad = (TPad *) canvasQATest->cd(2);
+  if (cPad->GetAbsXlowNDC() + cPad->GetTopMargin() + cPad->GetBottomMargin() != 0.0) result++;
+  cPad = (TPad *) canvasQATest->cd(3);
+  if (cPad->GetAbsXlowNDC() + cPad->GetTopMargin() + cPad->GetBottomMargin() != 0.0) result++;
+  cPad = (TPad *) canvasQATest->cd(4);
+  if (cPad->GetAbsXlowNDC() + cPad->GetLeftMargin() < 0.3) result++;
+
+  if (result == 0) {
+    ::Info("AliPainterTest","AliPainter::DivideTPad(\"canvasQATest\",\"<horizontal>[1b,1m,1m,1lst0.3]\",\"test\")- IsOK");
+  }else{
+    ::Error("AliPainterTest","AliDrawStyle::ApplyStyle(\"canvasQATest\",\"<horizontal>[1b,1m,1m,1lst0.3]\",\"test\")- FAILED");
+  }
 }

--- a/STAT/test/CMakeLists.txt
+++ b/STAT/test/CMakeLists.txt
@@ -5,3 +5,5 @@ add_test("func_STAT_AliTMinuitToolkitTest"
          bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliTMinutiToolkitTestLinear")
 add_test("func_STAT_AliDrawStyleTest"
          bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliDrawStyleTest")
+add_test("func_STAT_AliPainterTest"
+    bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliPainterTest")

--- a/STAT/test/alirootTestStyle.css
+++ b/STAT/test/alirootTestStyle.css
@@ -7,31 +7,31 @@ examples of css style in aliroot:
 TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 - means obj1 from TGraph with any tag(Status, Warnings, Errors) and TPC.QA.dcar_posA_1 from TGraph with tag Status.
 */
 TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1   {
-    marker_size:   1,2,3,4;
-    marker_color:  5,6,7,8; /* marker_color defenition */
-    line_color:    5,6,7,8; /* line_color defenition */
-    line_style:    13,14,15,16;
+    marker-size:   1,2,3,4;
+    marker-color:  5,6,7,8; /* marker-color defenition */
+    line-color:    5,6,7,8; /* line-color defenition */
+    line-style:    13,14,15,16;
 }
 
 .deadBand   {
-    marker_size:   1,1,1;
-    marker_color:  400,632,416;; /* marker_color defenition */
-    line_color:    2,3,4;/* line_color defenition */
-    line_style:    2,3,4;
+    marker-size:   1,1,1;
+    marker-color:  400,632,416;; /* marker-color defenition */
+    line-color:    2,3,4;/* line-color defenition */
+    line-style:    2,3,4;
 }
 
 .multiGraph   {      /*like figTemplateTRD   markerstyles: 20,21,24,25,27,28,34,33,29,30*/
-    marker_size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
-    marker_color:  1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
-    line_color:    1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
-    line_style:    1,2,3,4,5,6,7,8,9,10;
+    marker-size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
+    marker-color:  1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
+    line-color:    1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
+    line-style:    1,2,3,4,5,6,7,8,9,10;
 }
 
 .multiGraphPair   {    /*like figTemplateTRDPair markerstyles: 20,21,24,25,27,28,34,33,29,30*/
-    marker_size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
-    marker_color:  1,2,3,4,5,6,7,8,9,10; /* marker_color defenition */
-    line_color:    1,2,3,4,5,6,7,8,9,10; /* line_color defenition */
-    line_style:    1,1,1,1,1,1,1,1,1;
+    marker-size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
+    marker-color:  1,2,3,4,5,6,7,8,9,10; /* marker-color defenition */
+    line-color:    1,2,3,4,5,6,7,8,9,10; /* line-color defenition */
+    line-style:    1,1,1,1,1,1,1,1,1;
 }
 
 /*
@@ -39,38 +39,38 @@ TF1.Status, .Status#obj1, #obj3 - means any object from TF1 class with tag Statu
 */
 
 TF1.Status, .Status#obj1, #obj3   {
-    marker_size:   17,18,19,20;
-    marker_color:  21,22,23,24;
-    line_color:    25,26,27,28;
-    line_style:    29,30,31,32;
+    marker-size:   17,18,19,20;
+    marker-color:  21,22,23,24;
+    line-color:    25,26,27,28;
+    line-style:    29,30,31,32;
 }
 
 .Status#obj1, #obj3, TGraphErrors.Warning   {
-    marker_size:   33,34,35,36;
-    marker_color:  37,38,39,40;
-    line_color:    41,42,43,44;
-    line_style:    45,46,47,48;
+    marker-size:   33,34,35,36;
+    marker-color:  37,38,39,40;
+    line-color:    41,42,43,44;
+    line-style:    45,46,47,48;
 }
 
 /*
-TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 - means apply the value of marker_size, marker_color, line_color, line_style for obj1 of class TH1 with tag Status and obj1 from TH1 with tag Warning and for obj3 from TH1 with tag Warning.
+TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 - means apply the value of marker-size, marker-color, line-color, line-style for obj1 of class TH1 with tag Status and obj1 from TH1 with tag Warning and for obj3 from TH1 with tag Warning.
 */
 TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3   {
-    marker_size:   49,50,51,52;
-    marker_color:  53,54,55,56; /* marker_color defenition */
-    line_color:    57,58,59,60;
-    line_style:    61,62,63,64;
+    marker-size:   49,50,51,52;
+    marker-color:  53,54,55,56; /* marker-color defenition */
+    line-color:    57,58,59,60;
+    line-style:    61,62,63,64;
 }
 
 .statusPad#Top {
-    bottom_margin:   0.001;
-    right_margin:    0.05;
+    margin-bottom:   0.001;
+    margin-right:    0.05;
 }
 
 .statusPad#Bottom{
-    bottom_margin:   0.4;
-    right_margin:    0.05;
-    top_margin:      0.0;  
+    margin-bottom:   0.4;
+    margin-right:    0.05;
+    margin-top:      0.0;  
     gridX:           3;   
     gridY:           1;
 }

--- a/STAT/test/figTemplate.css
+++ b/STAT/test/figTemplate.css
@@ -2,8 +2,8 @@
 Implementations of template for QA via css convention.
 Style created for this example:
 todo: add link on some test function
+todo: add nice fitter | priority: high @Boris
 fixme: ApplyStyle doesn't work with huge name of object like this "hisK0DMassQPtTgl(0,100,0:80:20:20,0,10)(0)(gaus)(div=0,,class=Mass,dOption=E)[0].calss(Mass)" mb problem in class=Mass
-todo: if we want to draw histograms on the one pad we can use only arrays of ranges, in the rest cases redrawing
 {
     TFile::SetCacheFileDir(".");
     TFile *finput = TFile::Open("http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/alice/data/2015/LHC15o/pass1/LHC15o.pass1.B1.Bin0/performanceHisto.root","CACHEREAD");
@@ -16,16 +16,16 @@ todo: if we want to draw histograms on the one pad we can use only arrays of ran
     }
     AliDrawStyle::SetDefaults();
     AliDrawStyle::ApplyStyle("figTemplate");
-    AliDrawStyle::RegisterCssStyle("figTemplate", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/figTemplate.css"));
+    AliDrawStyle::RegisterCssStyle("figTemplate", AliDrawStyle::ReadCSSFile("$AliRoot-SRC/STAT/test/figTemplate.css"));
     //
     // Use Canvas41 default layout
     TCanvas *canvasQA = new TCanvas("canvasQA", "canvasQA", 1200, 800);
-    AliPainter::DivideTPad(canvasQA, "<horizontal>[1b,1t,1,1]", "Canvas41");
+    AliPainter::DivideTPad("<horizontal>[1b,1t,1,1]", "Canvas41",canvasQA);
     canvasQA->cd(1);
     AliPainter::DrawHistogram("hisPtAll(0,10)(0)()(div=1,dOption=E,class=PtAll)", hisArray);
     AliPainter::DrawHistogram("hisPtITS(0,10)(0)()(div=1,dOption=E,class=PtIts)", hisArray);
     AliPainter::DrawHistogram("hisK0DMassQPtTgl(1,1)(2)()(div=1,dOption=E,class=Tgl)", hisArray);
-    AliPainter::DrawHistogram("hisK0DMassQPtTgl(20,80,0:80:20:20,0,10)(0)(gaus,W)(class=Mass,dOption=E)", hisArray);
+    AliPainter::DrawHistogram("hisK0DMassQPtTgl(20,80,0:80:20:20,0,10)(0)(gaus,W)(div=1,class=Mass,dOption=E)", hisArray);
     AliDrawStyle::ApplyCssStyle(canvasQA, "figTemplate");
 
     TCanvas *canvasQA1 = new TCanvas("canvasQA", "canvasQA", 1200, 800);
@@ -33,108 +33,105 @@ todo: if we want to draw histograms on the one pad we can use only arrays of ran
     canvasQA1->cd(1);
     AliPainter::DrawHistogram("hisK0DMassQPtTgl(20,80,0:80:20:20,0,10)(0)(gaus,W)(class=Mass,dOption=E, x=[0,10000])", hisArray);
     AliDrawStyle::ApplyCssStyle(canvasQA1, "figTemplate");
-
 }
-
 */
 
-
 TH1*  {
-    title_font:63;
-    label_font:63;
-    marker_size: 1;
-    line_width: 0.5;
-    line_style: 7;
-    title_size: 20;
-    label_size: 20;
-    marker_style: 20,21,24,27;
-    marker_color: 14,2,4,8;
-    line_color: 14,1,4,8;
-    axis_color: 1,1,1,1;
-    title_offset:3.0;
+    title-font:63;
+    label-font:63;
+    marker-size: 1;
+    line-width: 0.5;
+    line-style: 7;
+    title-size: 20;
+    label-size: 20;
+    marker-style: 20,21,24,27;
+    marker-color: 14,2,4,8;
+    line-color: 14,1,4,8;
+    axis-color: 1,1,1,1;
+    title-offset:3.0;
 }
 
 .PtAll  {
-    marker_style: 20;
-    marker_color: 14;
-    line_color: 14;
-    label_size: 20;
+    marker-style: 20;
+    marker-color: 14;
+    line-color: 14;
+    label-size: 20;
 }
 
 .PtIts  {
-    marker_style: 21;
-    marker_color: 2;
-    line_color: 2;
-    label_size: 20;
+    marker-style: 21;
+    marker-color: 2;
+    line-color: 2;
+    label-size: 20;
 }
 
 .Tgl    {
-    marker_style: 24;
-    marker_color: 4;
-    line_color: 4;
-    label_size: 20;
+    marker-style: 24;
+    marker-color: 4;
+    line-color: 4;
+    label-size: 20;
 }
 
 .Mass {
-    marker_style: 20,21,24,27;
-    marker_color: 14,2,4,8;
-    line_color: 14,1,4,8;
-    axis_color: 1,1,1,1;
-    label_size: 20;
+    marker-style: 20,21,24,27;
+    marker-color: 14,2,4,8;
+    line-color: 14,1,4,8;
+    axis-color: 1,1,1,1;
+    label-size: 20;
 }
 
 TPad {
-   gridX:       0;
-   gridY:       0;
-   fill_color:  10,10,10,10;
-   tickX:       1,1,1,1;
-   tickY:       1,1,1,1;
-   logY:        0,0,0,1;
-   border_mode: 0,0,0,0;
-   bottom_margin:0.15;
+    gridX:         0;
+    gridY:         0;
+    fill-color:    10,10,10,10;
+    tickX:         1,1,1,1;
+    tickY:         1,1,1,1;
+    logY:          0,0,0,1;
+    border-mode:   0,0,0,0;
+    margin-bottom: 0.15;
 }
 
 .Canvas41 {     /*default canvas layout for  4x1 pad canvas*/
-    height:     1200;  /*to fix - read pixel as a size to be like CSS*/
-    width:      800;
-    gridX:       1;
-   gridY:       1;
-   fill_color:  10,10,10,10;
-   tickX:       1,1,1,1;
-   tickY:       1,1,1,1;
-   logY:        0,0,0,1;
-   border_mode: 0,0,0,0;
-    bottom_margin:0.15;
-    right_margin:0.05;
-    /* legend_format: <name> <range=%f>*/
+    height:        1200;  /*to fix - read pixel as a size to be like CSS*/
+    width:         800;
+    gridX:         1;
+    gridY:         1;
+    fill-color:    10,10,10,10;
+    tickX:         1,1,1,1;
+    tickY:         1,1,1,1;
+    logY:          0,0,0,1;
+    border-mode:   0,0,0,0;
+    margin-bottom: 0.15;
+    margin-right:  0.05;
+    /* legend-format: <name> <range=%f>*/
 }
 
 .Canvas22 {     /*default canvas layout for  2x2 pad canvas*/
-    height:     1200;  /*to fix - read pixeal as a size to be like CSS*/
-    width:      800;
-    gridX:       1;
-   gridY:       1;
-   fill_color:  10,10,10,10;
-   tickX:       1,1,1,1;
-   tickY:       1,1,1,1;
-   logY:        0,0,0,1;
-   border_mode: 0,0,0,0;
-    bottom_margin:0.15;
-    /* legend_format: <name> <range=%f>*/
+    height:        1200;  /*to fix - read pixeal as a size to be like CSS*/
+    width:         800;
+    gridX:         1;
+    gridY:         1;
+    fill-color:    10,10,10,10;
+    tickX:         1,1,1,1;
+    tickY:         1,1,1,1;
+    logY:          0,0,0,1;
+    border-mode:   0,0,0,0;
+    margin-bottom: 0.15;
+    /* legend-format: <name> <range=%f>*/
 }
 
 .Canvas1 { /*default canvas layout for  1 pad canvas*/
-    height:     500;
-    width:      700;
-    gridX:       0;
-   gridY:       0;
-   fill_color:  10,10,10,10;
-   tickX:       1,1,1,1;
-   tickY:       1,1,1,1;
-   logY:        0,0,0,1;
-   border_mode: 0,0,0,0;
-    bottom_margin: 0.15;
-    right_margin: 0.05;
-    top_margin: 0.1;
-    /* legend_format: <name> <range=%f>*/
+    height:        500;
+    width:         700;
+    gridX:         0;
+    gridY:         0;
+    fill-color:    10,10,10,10;
+    tickX:         1,1,1,1;
+    tickY:         1,1,1,1;
+    logY:          0,0,0,1;
+    border-mode:   0,0,0,0;
+    margin-bottom: 0.15;
+    margin-right:  0.05;
+    margin-top:    0.1;
+    /* legend-format: <name> <range=%f>*/
 }

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -75,7 +75,7 @@ EOF
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
 
   TEST_STATUS=0
-  if [[ $N_GOOD != 27 ]]; then
+  if [[ $N_GOOD != 33 ]]; then
     alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi
@@ -92,5 +92,32 @@ EOF
 
 }
 
+testAliPainterTest() {
+  cp $ALIROOT_SOURCE/STAT/test/AliPainterTest.C .
+  root -n -b -l <<\EOF 2>&1 | tee AliPainterTest.log
+    gSystem->AddIncludePath("-I$ALICE_ROOT/include");
+    .x ./AliPainterTest.C+
+EOF
+
+  N_GOOD=$(grep -cE 'Ali.*OK' AliPainterTest.log)
+  N_BAD=$(grep -c "E-Ali" AliPainterTest.log)
+
+  TEST_STATUS=0
+  if [[ $N_GOOD != 18 ]]; then
+    alilog_error "statTest.AliPainterTest: Test FAILED"
+    ((TEST_STATUS++))
+  fi
+  if [[ $N_BAD != 0 ]]; then
+    alilog_error "statTest.AliPainterTest: Test FAILED"
+    ((TEST_STATUS+=2))
+  fi
+  if [[ $TEST_STATUS == 0 ]]; then
+    alilog_success "statTest.AliPainterTest: All OK"
+  else
+    alilog_error "statTest.: FAILED (code $TEST_STATUS)"
+  fi
+  exit $TEST_STATUS
+
+}
 
 [[ $1 ]] && $1

--- a/STAT/test/test1.css
+++ b/STAT/test/test1.css
@@ -1,34 +1,34 @@
 TGraph   {
-  marker_size:   0.3,0.6,1.2;
-  marker_color:  3,6,9;
-  marker_style:  3,4,5;
-  line_color:    1,3,6;
-  line_style:    1,2,3;
-  line_width:    0.9,1.4,1.9;
-  fill_color:    0,0,0;
-  fill_style:    0,0,0;
+  marker-size:   0.3,0.6,1.2;
+  marker-color:  3,6,9;
+  marker-style:  3,4,5;
+  line-color:    1,3,6;
+  line-style:    1,2,3;
+  line-width:    0.9,1.4,1.9;
+  fill-color:    0,0,0;
+  fill-style:    0,0,0;
 }
 
 TH1F    {
-  marker_size:   0.3,0.6,1.2;
-  marker_color:  10,12,14;
-  marker_style:  3,4,5;
-  line_color:    2,4,8;
-  line_style:    1,2,3;
-  line_width:    0.9,1.4,1.9;
-  fill_color:    0,0,0;
-  fill_style:    0,0,0;
+  marker-size:   0.3,0.6,1.2;
+  marker-color:  10,12,14;
+  marker-style:  3,4,5;
+  line-color:    2,4,8;
+  line-style:    1,2,3;
+  line-width:    0.9,1.4,1.9;
+  fill-color:    0,0,0;
+  fill-style:    0,0,0;
 }
 
 TPad.Raw#pad   {
-  fill_color:    2,2,2;
-  fill_style:    1,2,3;
-  bottom_margin: 0;
-  top_margin:    0;
-  left_margin:   0;
-  right_margin:  0;
-  border_size:   1;
-  border_mode:   2;
+  fill-color:    #f5f5f0,#f5f5f0;
+  fill-style:    1,2;
+  margin-bottom: 0;
+  margin-top:    0;
+  margin-left:   0;
+  margin-right:  0;
+  border-size:   1;
+  border-mode:   2;
   gridX:         1;
   gridY:         1;
   tickX:         1;
@@ -40,7 +40,7 @@ TPad.Raw#pad   {
 }
 
 TCanvas    {
-  fill_color:    3;
-  border_size:   1;
-  border_mode:   2;
+  fill-color:    3;
+  border-size:   1;
+  border-mode:   2;
 }

--- a/STAT/test/test2.css
+++ b/STAT/test/test2.css
@@ -1,30 +1,30 @@
 TCanvas    {
-  fill_color:    2;
-  border_size:   1;
-  border_mode:   2;
+  fill-color:    2;
+  border-size:   1;
+  border-mode:   2;
 }
 
 
 TGraph   {
-  marker_size:   0.3,0.6,1.2;
-  marker_color:  2,4,6;
-  marker_style:  3,4,5;
-  line_color:    3,6,9;
-  line_style:    1,2,3;
-  line_width:    0.9,1.4,1.9;
-  fill_color:    0,0,0;
-  fill_style:    0,0,0;
+  marker-size:   0.3,0.6,1.2;
+  marker-color:  2,4,6;
+  marker-style:  3,4,5;
+  line-color:    3,6,9;
+  line-style:    1,2,3;
+  line-width:    0.9,1.4,1.9;
+  fill-color:    0,0,0;
+  fill-style:    0,0,0;
 
 }
 
 
 TH1F   {
-  marker_size:   1.2,2.4,4.8;
-  marker_color:  1,3,5;
-  marker_style:  6,8,10;
-  line_color:    8,10,12;
-  line_style:    1,2,3;
-  line_width:    2.1,2.5,2.9;
-  fill_color:    0,0,0;
-  fill_style:    0,0,0;
+  marker-size:   1.2,2.4,4.8;
+  marker-color:  1,3,5;
+  marker-style:  6,8,10;
+  line-color:    8,10,12;
+  line-style:    1,2,3;
+  line-width:    2.1,2.5,2.9;
+  fill-color:    0,0,0;
+  fill-style:    0,0,0;
 }


### PR DESCRIPTION
Hello Marian.

Description of changes:

AliDrawStyle:
  verbose mode added for AliDrawStyle::GetNamedIntegerAt()
  AliDrawStyle::GetNamedIntegerAt() more stable (fixed bug with float numbers)
  fixed all warning with typecasting
  AliDrawStyle::ColorConverter() added in AliDrawStyle. now all colors goes through   this converter. so we suppot rgb, hex and classic root format 
  verbose mode added for AliDrawStyle::GetProperty()
  fixed bug with using of empty properties
  AliDrawStyle::TF1ApplyStyle() extended for more attributes

AliPainter:
  In AliPainter::DivideTPad() fixed bug with empty class name
  AliPainter::OptionStringParser more stable:
  added check for empty input string
  added check for indexOutOfRange
  Some names of variables changed. Now it more readable

AliDrawStyleTest:
  test for AliDrawStyle::ConvertColor() added
  duplicates removed
  output more readable

AliPainterTest is working now:
  Added test for:
    OptionStringParser();
    PandasOptionParser();
    RangesParser();
    ArgsParser();
    DivideTPad();

*.css
  changed all css files according to css notation:
    bottom-margin, etc changed to margin-bottom etc so IDE intellisense for css recognises it
  In all old attributes "_" replaced to "-"

Code installed without errors and all tests passed
