### PR TITLE
ATO-418: AliPainter and AliDrawStyle

### DIFF
--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -730,7 +730,7 @@ Float_t AliDrawStyle::PrepareValue(const char* styleName, TString propertyName, 
   else if (propertyName.Contains("size") || propertyName.Contains("margin")) {
     property = AliDrawStyle::GetValue(styleName, "", elementID, classID, objectID, "", verbose);
     hisNum = objNum;
-    cProperty = propertyName;
+    cProperty = propertyName + ":";
     if (!property.Contains(cProperty)) {
       if (verbose == 4) ::Info("AliDrawStyle","AliDrawStyle::PrepareValue(\"%s\", \"%s\", \"%s\", \"%s\", \"%s\") property not found in css file", styleName, propertyName.Data(), elementID.Data(), classID.Data(), objectID.Data());
       return -1.;
@@ -752,6 +752,35 @@ Float_t AliDrawStyle::PrepareValue(const char* styleName, TString propertyName, 
   return -1.0;
 }
 
+//TODO: add test for this @Boris
+///
+/// \param inputCSS
+/// \param cssArray
+/// \param verbose
+/// \return
+TObjArray *AliDrawStyle::ReadCssString(TString inputCSS, TObjArray *cssArray, Int_t verbose) {
+  while (inputCSS.Index("*/") > 0) {
+    inputCSS = TString(inputCSS(0, inputCSS.Index("/*"))) + TString(inputCSS(inputCSS.Index("*/")+2, inputCSS.Length()));
+  }
+  inputCSS.ReplaceAll("\n", ""); //  check performance and implement better variant;
+  TObjArray *tokenArray = inputCSS.Tokenize("{}");   //assuming we can not use {} symbols in the style IDS
+  Int_t entries = tokenArray->GetEntries();
+  if (cssArray==nullptr) {
+    cssArray = new TObjArray(entries / 2);
+  }
+  if (verbose == 4)
+    ::Info("AliDrawStyle::ReadCSSString","In input CSS string %s was parsed to:\n", inputCSS.Data());
+  for (Int_t i = 0; i < entries; i += 2) {
+    if (i + 1 >= entries) continue;
+    TString selector = tokenArray->At(i)->GetName();
+    TString declaration = tokenArray->At(i + 1)->GetName();
+    if (verbose == 4)
+      printf("selector: %s\ndeclaration: %s\n", selector.Data(), declaration.Data());
+    cssArray->AddLast(new TNamed(selector.Data(), declaration.Data()));
+  }
+  return cssArray;
+}
+
 /// Read CSS html like files  (*see also AliRoot modification in CSS)
 /// TODO:
 /// * proper exception  handling (Boris)
@@ -765,24 +794,9 @@ TObjArray *AliDrawStyle::ReadCSSFile(const char *  inputName, TObjArray * cssArr
     ::Error("AliDrawStyle::ReadCSSFile","File %s doesn't exist", inputName);
     return nullptr;
   }
+
   TString inputCSS = gSystem->GetFromPipe(TString::Format("cat %s",inputName).Data());     // I expect this variable is defined
-  //remove comments:
-  while (inputCSS.Index("*/") > 0) {
-    inputCSS = inputCSS(0, inputCSS.Index("/*")) + inputCSS(inputCSS.Index("*/")+2, inputCSS.Length());
-  }
-  //inputCSS.ReplaceAll("\n", ""); //  check performance and implement better variant;
-  TObjArray *tokenArray = inputCSS.Tokenize("{}");   //assuming we can not use {} symbols in the style IDS
-  Int_t entries = tokenArray->GetEntries();
-  if (cssArray==nullptr) {
-    cssArray = new TObjArray(entries / 2);
-  }
-  for (Int_t i = 0; i < entries; i += 2) {
-    if (i + 1 >= entries) continue;
-    TString selector = tokenArray->At(i)->GetName();
-    TString declaration = tokenArray->At(i + 1)->GetName();
-    cssArray->AddLast(new TNamed(selector.Data(), declaration.Data()));
-  }
-  return cssArray;
+  return AliDrawStyle::ReadCssString(inputCSS, cssArray, verbose);
 }
 
 /// Write cssArray to the file as a plain array (recursive function)
@@ -1092,7 +1106,7 @@ TString AliDrawStyle::GetValue(const char *styleName, TString propertyName, TStr
 */
 void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *cGraph, Int_t objNum, Int_t verbose) {
 
-  AliDrawStyle::ObjectApplyStyle(styleName, cGraph, objNum, verbose);
+  AliDrawStyle::TObjectApplyStyle(styleName, cGraph, objNum, verbose);
 
   Bool_t status = kFALSE;
   TString elementID = "";
@@ -1110,6 +1124,20 @@ void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *cGraph, Int_t
     cGraph->GetXaxis()->SetAxisColor((Color_t) valueI);
     cGraph->GetYaxis()->SetAxisColor((Color_t) valueI);
   }
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status) {
+    cGraph->GetXaxis()->SetNdivisions(valueI);
+    cGraph->GetYaxis()->SetNdivisions(valueI);
+  }
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("x-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cGraph->GetXaxis()->SetNdivisions(valueI);
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("y-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cGraph->GetYaxis()->SetNdivisions(valueI);
 
   valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("label-color"), elementID, classID, objectID, localStyle, status, objNum, verbose);
   if (status) {
@@ -1162,7 +1190,7 @@ void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *cGraph, Int_t
 */
 void AliDrawStyle::TH1ApplyStyle(const char *styleName, TH1 *cHis, Int_t objNum, Int_t verbose) {
 
-  AliDrawStyle::ObjectApplyStyle(styleName, cHis, objNum, verbose);
+  AliDrawStyle::TObjectApplyStyle(styleName, cHis, objNum, verbose);
 
   Bool_t status = kFALSE;
   TString elementID = "";
@@ -1177,6 +1205,20 @@ void AliDrawStyle::TH1ApplyStyle(const char *styleName, TH1 *cHis, Int_t objNum,
 
   valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("axis-color"), elementID, classID, objectID, localStyle, status, objNum, verbose);
   if (status) cHis->SetAxisColor((Color_t) valueI);
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status) {
+    cHis->GetXaxis()->SetNdivisions(valueI);
+    cHis->GetYaxis()->SetNdivisions(valueI);
+  }
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("x-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cHis->GetXaxis()->SetNdivisions(valueI);
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("y-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cHis->GetYaxis()->SetNdivisions(valueI);
 
   valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("label-color"), elementID, classID, objectID, localStyle, status, objNum, verbose);
   if (status) cHis->SetLabelColor((Color_t) valueI, "xyz");
@@ -1246,7 +1288,7 @@ void AliDrawStyle::TH1ApplyStyle(const char *styleName, TH1 *cHis, Int_t objNum,
 
   //TODO: how to make it not only for TF1? @Boris
   for (Int_t i = 0; i < cHis->GetListOfFunctions()->GetEntries(); i++) {
-    AliDrawStyle::ObjectApplyStyle(styleName, (TF1 *) cHis->GetListOfFunctions()->At(i), objNum, verbose);
+    AliDrawStyle::TObjectApplyStyle(styleName, (TF1 *) cHis->GetListOfFunctions()->At(i), objNum, verbose);
   }
 
 }
@@ -1261,7 +1303,7 @@ void AliDrawStyle::TH1ApplyStyle(const char *styleName, TH1 *cHis, Int_t objNum,
 */
 void AliDrawStyle::TF1ApplyStyle(const char *styleName, TF1 *cFunc, Int_t objNum, Int_t verbose) {
 
-  AliDrawStyle::ObjectApplyStyle(styleName, cFunc, objNum, verbose);
+  AliDrawStyle::TObjectApplyStyle(styleName, cFunc, objNum, verbose);
 
   Bool_t status = false;
   TString elementID = "";
@@ -1279,6 +1321,20 @@ void AliDrawStyle::TF1ApplyStyle(const char *styleName, TF1 *cFunc, Int_t objNum
     cFunc->GetYaxis()->SetAxisColor((Color_t) valueI);
     if (cFunc->GetZaxis()) cFunc->GetZaxis()->SetAxisColor((Color_t) valueI);
   }
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status) {
+    cFunc->GetXaxis()->SetNdivisions(valueI);
+    cFunc->GetYaxis()->SetNdivisions(valueI);
+  }
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("x-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cFunc->GetXaxis()->SetNdivisions(valueI);
+
+  valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("y-ndivisions"), elementID, classID, objectID, localStyle, status, objNum, verbose);
+  if (status)
+    cFunc->GetYaxis()->SetNdivisions(valueI);
 
   valueI = (Int_t) AliDrawStyle::PrepareValue(styleName, TString("label-font"), elementID, classID, objectID, localStyle, status, objNum, verbose);
   if (status) {
@@ -1441,7 +1497,7 @@ void AliDrawStyle::TLegendApplyStyle(const char *styleName, TLegend *cLegend, In
 /// \param verbose
 /// \return
 template <typename T>
- void AliDrawStyle::ObjectApplyStyle(const char *styleName, T *cObj, Int_t objNum, Int_t verbose) {
+ void AliDrawStyle::TObjectApplyStyle(const char *styleName, T *cObj, Int_t objNum, Int_t verbose) {
 
   Bool_t status = false;
   TString elementID = "";
@@ -1657,7 +1713,21 @@ void AliDrawStyle::TCanvasApplyCssStyle(const char *styleName, TCanvas *cCanvas,
 /// \param pad       - Input TPad object. You can specify TCanvas in this case style will be apply recursively to all objects (TH1, TF1, TGraph) on pad.
 /// \param styleName - Name of style specify in AliDrawStyle::RegisterCssStyle()
 /*!
-  ####  Example usage see in the beginnings of header file:
+##  List of available properties:
+### TObject
+marker-color; marker-size; marker-style; line-color; line-width; line-style; fill-color; fill-style;
+### TGraph
+axis-color; ndivisions; x-ndivisions; y-ndivisions; label-color; label-font; label-size; label-offset; title-font; title-offset; title-size;
+### TH1
+axis-color; ndivisions; x-ndivisions; y-ndivisions; label-color; Xlabel-color; Ylabel-color; Zlabel-color; label-font; Xlabel-font; Ylabel-font; Zlabel-font; label-size; Xlabel-size; Ylabel-size; Zlabel-size; label-offset; title-font; title-offset; Xtitle-offset; Ytitle-offset; Ztitle-offset; title-size; Xtitle-size; Ytitle-size; Ztitle-size;
+### TF1
+axis-color; ndivisions; x-ndivisions; y-ndivisions; label-font; label-size; label-offset; title-font; title-size; title-offset;
+### TLegend
+column-separation; margin; ncolumns; border-size; shadow-color; x1-ndc; x2-ndc; y1-ndc; y2-ndc; x1; x2; y1; y2; bbox-centerx; bbox-centery; bbox-x1; bbox-x2; bbox-y1; bbox-y2; line-color; line-style; line-width; fill-color; fill-style; text-align; text-angle; text-color; text-font; text-size;
+### TPad
+fill-color;  margin;  margin-bottom;  margin-top;  margin-left;  margin-right;  border-size;  border-mode;  gridX;  gridY;  tickX;  tickY;  logX;  logY;  logZ;
+### TCanvas
+width; height; fill-color;  highlight-color;  margin-bottom;  margin-top;  margin-left;  margin-right;  border-size;  border-mode;
 */
 void AliDrawStyle::ApplyCssStyle(TPad *pad, const char *styleName, Int_t verbose) {
   if (pad == nullptr) {

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -292,7 +292,7 @@ protected:
 public:
   static const TObjArray *GetCssStyle(const char *styleName) {return fCssStyleAlice[styleName];}
   template <typename T>
-    static void     ObjectApplyStyle(const char* styleName, T *cObj, Int_t objNum=0, Int_t verbose=0);
+    static void     TObjectApplyStyle(const char* styleName, T *cObj, Int_t objNum=0, Int_t verbose=0);
   static void       TGraphApplyStyle(const char* styleName, TGraph *cGraph, Int_t objNum=0, Int_t verbose=0);
   static void       TH1ApplyStyle(const char* styleName, TH1 *cHis, Int_t objNum=0, Int_t verbose=0);
   static void       TF1ApplyStyle(const char* styleName, TF1 *cFunc, Int_t objNum=0, Int_t verbose=0);
@@ -316,6 +316,7 @@ public:
   static Int_t      RgbToColor_t(const char *inputString, Int_t verbose=0);
   static Int_t      HexToColor_t(const char *inputString, Int_t verbose=0);
   static TObjArray *ReadCSSFile(const char *  inputName, TObjArray * array=nullptr, Int_t verbose=0);
+  static TObjArray *ReadCssString(TString  cssString, TObjArray *array=nullptr, Int_t verbose=0);
   static void       WriteCSSFile(TObjArray * cssArray, const char *  outputName, std::fstream *cssOut=nullptr);
   static Float_t   PrepareValue(const char* styleName, TString propertyName, TString elementID, TString classID, TString objectID,                                        TString localStyle, Bool_t &status, Int_t objNum=0, Int_t verbose=0);
   ClassDef(AliDrawStyle,1);

--- a/STAT/AliPainter.cxx
+++ b/STAT/AliPainter.cxx
@@ -63,7 +63,7 @@ std::vector<TString> AliPainter::rangesVec;
 *       \code
 *         TFile::SetCacheFileDir(".");
 *         TFile *finput = TFile::Open("http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/AliPainterTest.root","CACHEREAD");
-*         TTree *tree = (TTree *) finput.Get("hisPtAll");
+*         TTree *tree = (TTree *) finput->Get("hisPtAll");
 *         hisArray = new TObjArray();
 *         TList *keys = finput->GetListOfKeys();
 *         for (Int_t iKey = 0; iKey<keys->GetEntries();iKey++) {
@@ -415,7 +415,7 @@ void AliPainter::RangesToMap(TString range, Int_t axisNum, axisRangesMap &result
 *       \code
 *         TFile::SetCacheFileDir(".");
 *         TFile *finput = TFile::Open("http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/AliPainterTest.root","CACHEREAD");
-*         TTree *tree = (TTree *) finput.Get("hisPtAll");
+*         TTree *tree = (TTree *) finput->Get("hisPtAll");
 *         hisArray = new TObjArray();
 *         TList *keys = finput->GetListOfKeys();
 *         for (Int_t iKey = 0; iKey<keys->GetEntries();iKey++) {
@@ -720,7 +720,7 @@ void AliPainter::ParsePandasString(const TString optionsStr, std::map<TString, T
     if (verbose == 4) ::Info("AliPainter::ParsePandasString", "From string - \"%s\" key is \"%s\"", optionStr.Data(), key.Data());
     value = TString(optionStr(optionStr.Index("=") + 1, optionStr.Length())).ReplaceAll(" ", "");
     if (verbose == 4) ::Info("AliPainter::ParsePandasString", "From string - \"%s\" value is \"%s\"", optionStr.Data(), value.Data());
-    if (optMap.find(key) == optMap.end()) {
+    if (optMap.find(key) == optMap.end() && key != TString()) {
       TString defaultKeys = "";
       for (std::map<TString, TString>::iterator it=optMap.begin(); it!=optMap.end(); ++it)
         defaultKeys += it->first + ",";


### PR DESCRIPTION
Hello Marian.

Latest modifications are:
 ### AliPainter:
* Warning output for PandasParser was simplified.
### AliDrawStyle:
* Bug with margins(if specified side-margin it was applied to all margin) fixed;
* Added ndivision property(ndivisions for both -x,y and x-ndivisions, y-ndivisions);
* Function ReadCSSString was added. Now you can copy content of your css file to TString and parse it to array;
* List of available properties was added to the ApplyCssStyle description;

Can you check documentation, please. [Here](http://alidoc.cern.ch/AliRoot/master/class_ali_painter.html) we still don't have pictures for new examples, but I guess that it still not refresh. 

_Code was installed without error. All tests passed._

Boris